### PR TITLE
Add is_dir to HTTP backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='stored',
-    version='0.0.29',
+    version='0.0.30',
     description='Manage files and directories on different storage backends.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/stored/backends/http.py
+++ b/stored/backends/http.py
@@ -20,3 +20,6 @@ class HTTPStorage(object):
 
     def sync_from(self, input_path):
         raise NotImplementedError('sync_from is not implemented for HTTPStorage backend')
+
+    def is_dir(self):
+        return False

--- a/tests/backends/test_http.py
+++ b/tests/backends/test_http.py
@@ -39,3 +39,8 @@ def test_list(temp_dir):
 def test_list_relative(temp_dir):
     with pytest.raises(NotImplementedError):
         HTTPStorage('foo').list(relative=True)
+
+
+def test_is_dir_always_false():
+    assert not HTTPStorage('foo.zip').is_dir()
+    assert not HTTPStorage('foo').is_dir()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -56,6 +56,14 @@ def test_sync_to_dirs(temp_dir, sample_local_dir):
     assert sorted(actual) == sorted(expected)
 
 
+def test_sync_to_archives_without_unzip(temp_dir, sample_local_zip_url):
+    temp_file = os.path.join(temp_dir, os.path.basename(sample_local_zip_url))
+    sync(sample_local_zip_url, temp_file)
+    actual = list_files(temp_dir, relative=True)
+    expected = ['foo.zip']
+    assert sorted(actual) == sorted(expected)
+
+
 def test_sync_to_dirs_some_existing_files(temp_dir, sample_local_dir):
     bar_path = os.path.join(temp_dir, 'bar.txt')
     touch(bar_path)


### PR DESCRIPTION
I hit this while doing a sync from a remote/http archive to a local archive (without decompressing):
```
  File "/usr/local/lib/python3.6/site-packages/stored/sync.py", line 24, in sync
    elif Archive(output_path).valid and input_storage.is_dir():
AttributeError: 'HTTPStorage' object has no attribute 'is_dir'
```