### PR TITLE
 Fix archive extension extraction for URLs with query strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='stored',
-    version='0.0.30',
+    version='0.0.31',
     description='Manage files and directories on different storage backends.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/stored/archive.py
+++ b/stored/archive.py
@@ -3,6 +3,8 @@ import tarfile
 import zipfile
 import shutil
 
+from urllib.parse import urlparse
+
 from .utils import ChangeDirectory
 
 
@@ -45,6 +47,8 @@ class Archive(object):
             zip_file.extractall(output_dir)
 
     def _extension(self, path):
+        if '://' in path:
+            path = urlparse(path).path
         if path.endswith('.tar.gz'):
             return '.tar.gz'
         return os.path.splitext(path)[1]

--- a/stored/archive.py
+++ b/stored/archive.py
@@ -3,7 +3,10 @@ import tarfile
 import zipfile
 import shutil
 
-from urllib.parse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 from .utils import ChangeDirectory
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -41,3 +41,9 @@ def test_create_zip(temp_dir, sample_local_dir):
     output_file = os.path.join(temp_dir, 'foo.zip')
     Archive(output_file).create(sample_local_dir)
     assert os.path.exists(output_file)
+
+
+def test_url_extension():
+    assert '.zip' == Archive('http://example.com/foo/bar.zip?baz').extension
+    assert '.zip' == Archive('http://example.com/foo.zip?bar.com&baz').extension
+    assert '.tar.gz' == Archive('http://example.com/foo.tar.gz?foo').extension


### PR DESCRIPTION
```python
assert '.zip' == Archive('http://example.com/foo/bar.zip?baz').extension
assert '.zip' == Archive('http://example.com/foo.zip?bar.com&baz').extension
assert '.tar.gz' == Archive('http://example.com/foo.tar.gz?foo').extension
```